### PR TITLE
Shell out for `ps` instead of using the gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "sys-proctable"
 gem "json"
 gem "sequel"
 gem "slop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.9.18)
     json (2.1.0)
     sequel (4.48.0)
     slop (4.5.0)
     sqlite3 (1.3.13)
-    sys-proctable (1.1.4-universal-aix5)
-    sys-proctable (1.1.4-universal-darwin)
-      ffi
 
 PLATFORMS
   ruby
@@ -19,7 +15,6 @@ DEPENDENCIES
   sequel
   slop
   sqlite3
-  sys-proctable
 
 BUNDLED WITH
    1.15.1

--- a/lib/ps.rb
+++ b/lib/ps.rb
@@ -1,0 +1,33 @@
+module GoodDog
+  class SubprocessError < StandardError; end
+
+  module PS
+    # Returns an array of hashes whose keys are the columns in the `ps` output.
+    module_function def aux
+      processes = `ps aux 2>&1`
+      if $?.exitstatus != 0
+        raise SubprocessError, "Unable to run `ps`! Output was: #{processes}"
+      end
+
+      data = processes.each_line.map(&:chomp)
+      headers = data[0].split(" ")
+      data = data[1..-1]
+
+      data.map do |line|
+        # Limit the split to headers.length because commands are likely to have spaces.
+        # It'd sure be nice if `ps` had \t-delimited output, huh?
+        headers.zip(line.split(" ", headers.length)).to_h
+      end
+    end
+
+    module_function def command_running?(name, fuzzy: true)
+      aux.any? do |process|
+        if fuzzy
+          process["COMMAND"].match? name
+        else
+          process["COMMAND"] == name
+        end
+      end
+    end
+  end
+end

--- a/lib/running_check.rb
+++ b/lib/running_check.rb
@@ -1,11 +1,7 @@
-require 'sys/proctable'
-include Sys
+require_relative "ps"
 
 def warn_if_running
-  ProcTable.ps do |proc|
-    if proc.name == 'Stay'
-      puts "WARNING: Stay is currently running (process #{proc.pid}). Changes to the database may not be kept!"
-      break
-    end
+  if GoodDog::PS.command_running? "Stay"
+    puts "WARNING: Stay is currently running. Changes to the database may not be kept!"
   end
 end

--- a/lib/running_check.rb
+++ b/lib/running_check.rb
@@ -2,6 +2,6 @@ require_relative "ps"
 
 def warn_if_running
   if GoodDog::PS.command_running? "Stay"
-    puts "WARNING: Stay is currently running. Changes to the database may not be kept!"
+    $stderr.puts "WARNING: Stay is currently running. Changes to the database may not be kept!"
   end
 end


### PR DESCRIPTION
The `sys-proctable ` gem seems pretty inconvenient to install, so I thought it might be helpful to just parse `ps` output from the commandline.

Right now this strips the `pid` from the printed output since the "is this running?" function I wrote is just an interrogative, but I can add a way to get that back if you want it!

I also changed this to print the warning to stderr, just in case anyone wants to pipe the list output into something in the future.